### PR TITLE
Bug in ExtrinsicDeformation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.metadata
-import locale
 import os
 import sys
 import warnings

--- a/src/skshapes/morphing/extrinsic_deformation.py
+++ b/src/skshapes/morphing/extrinsic_deformation.py
@@ -127,7 +127,6 @@ class ExtrinsicDeformation(BaseModel):
             raise ShapeError(msg)
 
         p = parameter
-        p.requires_grad = True
 
         if self.control_points is False or shape.control_points is None:
             q = shape.points.clone()
@@ -136,7 +135,12 @@ class ExtrinsicDeformation(BaseModel):
             points = shape.points.clone()
             q = shape.control_points.points.clone()
             points.requires_grad = True
-        q.requires_grad = True
+
+        if not p.requires_grad:
+            p.requires_grad = True
+
+        if not q.requires_grad:
+            q.requires_grad = True
 
         # Compute the regularization
         regularization = torch.tensor(0.0, device=shape.device)


### PR DESCRIPTION
The current implementation of `ExtrinsicDeformation.morph(shape, parameter)` leads to error if `parameter.requires_grad = True` and parameter is not a leaf variable.

```python
model = sks.ExtrinsicDeformation(
      n_steps=2,
      kernel="gaussian",
      scale=0.5,
  )

  mesh = sks.Sphere().decimate(n_points=20)

  x = torch.rand(3)
  x.requires_grad = True
  parameter_shape = model.parameter_shape(shape=mesh)
  parameter = x.repeat(parameter_shape[0]).reshape(parameter_shape)

 model.morph(
      shape=mesh,
      parameter=parameter,
  )
```

To solve this, it suffices to call `parameter.requires_grad = True` only if it is not already the case. A test is added with a non-leaf variable as parameter to check that the execution does not lead to error, and check that the result of the morphing is consistent w.r.t. the same where the parameter does not requires `grad`.